### PR TITLE
Update mongoose to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob": "~3.2.6",
     "hiredis": "~0.1.15",
     "lodash": "~1.3.1",
-    "mongoose": "~3.6.19",
+    "mongoose": "~3.8.0",
     "mongoose-findorcreate": "~0.1.2",
     "mongoose-timestamp": "~0.1.1",
     "mongoose-types": "~1.0.3",


### PR DESCRIPTION
The old 3.6 dependency interfered with project requirements in more
recent projects (such as when using it with baucis for example).

The update is neccessary to use the model registry accross the project
and not jailed in node-ultimate.
