### PR TITLE
If an override exists, passing the controller as expected

### DIFF
--- a/lib/server/route/restify.js
+++ b/lib/server/route/restify.js
@@ -462,7 +462,7 @@ Restify.prototype.model = function (path, modelName, overrideController) {
         if (_.isObject(overrideController) &&
             _.has(overrideController, verb) &&
             _.isFunction(overrideController[verb])) {
-          self[role](path, overrideController[verb], [verb]);
+          self[role](path, overrideController, [verb]);
         } else {
           self[role](path, self._buildController(verb, Model, fields), [verb]);
         }


### PR DESCRIPTION
in restify.model, if a function existed to override one of the verbs, it was erroneously passing in the function instead of the controller. 
